### PR TITLE
Improve chat UI and settings persistence

### DIFF
--- a/constants/settings.ts
+++ b/constants/settings.ts
@@ -1,0 +1,16 @@
+import { AppSettings } from '@/types/settings';
+
+export const DEFAULT_SETTINGS: AppSettings = {
+  model: 'llama-3.3-70b',
+  temperature: 0.7,
+  topP: 0.9,
+  minP: 0.05,
+  maxTokens: 4096,
+  topK: 40,
+  repetitionPenalty: 1.2,
+  webSearch: 'auto',
+  webCitations: true,
+  includeSearchResults: true,
+  stripThinking: false,
+  disableThinking: false,
+};

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -1,0 +1,16 @@
+export type WebSearchMode = 'off' | 'auto' | 'on';
+
+export interface AppSettings {
+  model: string;
+  temperature: number;
+  topP: number;
+  minP: number;
+  maxTokens: number;
+  topK: number;
+  repetitionPenalty: number;
+  webSearch: WebSearchMode;
+  webCitations: boolean;
+  includeSearchResults: boolean;
+  stripThinking: boolean;
+  disableThinking: boolean;
+}

--- a/types/venice.ts
+++ b/types/venice.ts
@@ -1,0 +1,34 @@
+export interface VeniceModel {
+  id: string;
+  model_spec: {
+    name: string;
+    pricing: {
+      input: { usd: number; vcu: number; diem: number } | Record<string, number>;
+      output: { usd: number; vcu: number; diem: number } | Record<string, number>;
+    };
+    availableContextTokens?: number;
+    capabilities: {
+      optimizedForCode?: boolean;
+      quantization?: string;
+      supportsFunctionCalling?: boolean;
+      supportsReasoning?: boolean;
+      supportsResponseSchema?: boolean;
+      supportsVision?: boolean;
+      supportsWebSearch?: boolean;
+      supportsLogProbs?: boolean;
+    };
+    constraints: {
+      temperature?: { default?: number } | number;
+      top_p?: { default?: number } | number;
+      max_output_tokens?: { default?: number; max?: number } | number;
+      maxOutputTokens?: { default?: number; max?: number } | number;
+      max_tokens?: { default?: number; max?: number } | number;
+      response_tokens?: { default?: number; max?: number } | number;
+      [key: string]: any;
+    };
+    modelSource: string;
+    offline: boolean;
+    traits: string[];
+    beta?: boolean;
+  };
+}

--- a/utils/settingsStorage.ts
+++ b/utils/settingsStorage.ts
@@ -1,0 +1,73 @@
+import { Platform } from 'react-native';
+import * as FileSystem from 'expo-file-system';
+
+const STORAGE_KEY = 'vgpt-settings';
+const SETTINGS_FILE_PATH = FileSystem.documentDirectory
+  ? `${FileSystem.documentDirectory}${STORAGE_KEY}.json`
+  : null;
+
+type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
+
+type SettingsLike = Record<string, JsonValue>;
+
+export async function loadStoredSettings<T extends SettingsLike>(defaults: T): Promise<T> {
+  try {
+    if (Platform.OS === 'web') {
+      if (typeof localStorage === 'undefined') {
+        return defaults;
+      }
+
+      const savedSettings = localStorage.getItem(STORAGE_KEY);
+      if (savedSettings) {
+        const parsed = JSON.parse(savedSettings);
+        if (parsed && typeof parsed === 'object') {
+          return { ...defaults, ...parsed };
+        }
+      }
+
+      return defaults;
+    }
+
+    if (!SETTINGS_FILE_PATH) {
+      return defaults;
+    }
+
+    const fileInfo = await FileSystem.getInfoAsync(SETTINGS_FILE_PATH);
+    if (!fileInfo.exists) {
+      return defaults;
+    }
+
+    const stored = await FileSystem.readAsStringAsync(SETTINGS_FILE_PATH);
+    const parsed = JSON.parse(stored);
+
+    if (parsed && typeof parsed === 'object') {
+      return { ...defaults, ...parsed };
+    }
+
+    return defaults;
+  } catch (error) {
+    console.warn('Failed to load persisted settings', error);
+    return defaults;
+  }
+}
+
+export async function persistSettings<T extends SettingsLike>(settings: T): Promise<void> {
+  try {
+    if (Platform.OS === 'web') {
+      if (typeof localStorage === 'undefined') {
+        return;
+      }
+
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+      return;
+    }
+
+    if (!SETTINGS_FILE_PATH) {
+      return;
+    }
+
+    await FileSystem.writeAsStringAsync(SETTINGS_FILE_PATH, JSON.stringify(settings));
+  } catch (error) {
+    console.warn('Failed to persist settings', error);
+  }
+}


### PR DESCRIPTION
## Summary
- persist chat settings across platforms using shared defaults and a FileSystem-backed storage helper
- refine the chat surface with selectable message text, horizontal attachment previews, and smoother list performance tweaks
- harden the model picker UI with resilient metadata formatting, empty states, and shared Venice model typings

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_68d94e0809208331bb5c8426b23fb296

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Persist settings across web/native with shared defaults and storage, centralize types, and refine chat/model picker UI with selectable text, horizontal attachments, and FlatList performance tweaks.
> 
> - **Core**:
>   - Introduce `DEFAULT_SETTINGS` and shared types in `constants/settings.ts` and `types/{settings,venice}.ts`.
>   - Add cross-platform settings persistence via `utils/settingsStorage.ts` (localStorage on web, FileSystem on native).
>   - Refactor app to use shared types/defaults and async `loadStoredSettings`/`persistSettings`.
> - **Chat UI (`app/index.tsx`)**:
>   - Make message, thinking, and reference text selectable; add horizontal attachment previews via `ScrollView`.
>   - Improve list perf: memoized callbacks, `keyExtractor`, `maintainVisibleContentPosition`, platform-conditional `removeClippedSubviews`.
>   - Harden model picker item rendering with resilient pricing (`resolveUsdPrice`), metadata formatting, and empty state.
> - **Settings (`app/settings.tsx`)**:
>   - Use shared defaults/types and async persistence; memoize handlers; add loading indicator and empty state.
>   - Align model list item UI/pricing parsing with chat screen.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 041215ab712f5ff177f3ccd50f18b24c3b9af9d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->