### PR TITLE
Enable streaming chat and clean image generation UI

### DIFF
--- a/constants/venice.ts
+++ b/constants/venice.ts
@@ -1,0 +1,6 @@
+export const VENICE_API_BASE_URL = 'https://api.venice.ai/api/v1';
+export const VENICE_API_KEY = 'lnWNeSg0pA_rQUooNpbfpPDBaj2vJnWol5WqKWrIEF';
+
+export const VENICE_MODELS_ENDPOINT = `${VENICE_API_BASE_URL}/models`;
+export const VENICE_CHAT_COMPLETIONS_ENDPOINT = `${VENICE_API_BASE_URL}/chat/completions`;
+export const VENICE_IMAGE_GENERATIONS_ENDPOINT = `${VENICE_API_BASE_URL}/images/generations`;

--- a/utils/settingsStorage.ts
+++ b/utils/settingsStorage.ts
@@ -8,9 +8,7 @@ const SETTINGS_FILE_PATH = FileSystem.documentDirectory
 
 type JsonValue = string | number | boolean | null | JsonValue[] | { [key: string]: JsonValue };
 
-type SettingsLike = Record<string, JsonValue>;
-
-export async function loadStoredSettings<T extends SettingsLike>(defaults: T): Promise<T> {
+export async function loadStoredSettings<T>(defaults: T): Promise<T> {
   try {
     if (Platform.OS === 'web') {
       if (typeof localStorage === 'undefined') {
@@ -51,7 +49,7 @@ export async function loadStoredSettings<T extends SettingsLike>(defaults: T): P
   }
 }
 
-export async function persistSettings<T extends SettingsLike>(settings: T): Promise<void> {
+export async function persistSettings<T>(settings: T): Promise<void> {
   try {
     if (Platform.OS === 'web') {
       if (typeof localStorage === 'undefined') {


### PR DESCRIPTION
## Summary
- centralize Venice API configuration with the new key and shared endpoints
- switch chat completions to streaming SSE handling with richer error handling and attachment support
- refresh image generation UX with a collapsible advanced options drawer and broader image model detection
- relax settings storage typings so AppSettings can persist cleanly

## Testing
- `npx tsc --noEmit`
- `npm run lint` *(fails: ESLint not configured)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fa53abaa883318102044ae826a7af)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches chat to SSE streaming with attachment support, centralizes Venice API config, broadens image model handling, and adds an advanced image options drawer.
> 
> - **API/config**
>   - Centralize Venice API in `constants/venice.ts` (`VENICE_API_BASE_URL`, key, and shared endpoints) and replace hardcoded URLs/keys in `app/index.tsx` and `app/settings.tsx`.
>   - More robust model fetching/parsing (`data.data` or `data.models`) and richer error messages.
> - **Chat**
>   - Enable streaming SSE in `chat/completions` with incremental UI updates, thinking/content split, and citation/reference extraction.
>   - Add `AbortController` lifecycle management with long timeouts for reasoning models; improved cancellation handling.
>   - Support image attachments via data URLs in conversation history; persist per-response metrics (tokens, cost, t/s, time).
> - **Images**
>   - Broaden image-model detection logic and use model constraints to clamp `steps/width/height/guidance`.
>   - New collapsible “Advanced options” UI (size presets, steps, guidance); use shared image generation endpoint.
> - **Settings/storage**
>   - Relax settings storage typings in `utils/settingsStorage.ts`.
>   - Settings screen loads models via shared endpoints and auto-syncs `maxTokens` from model constraints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 791aa5a092cd75fa553d22c5432b6ffc9a07f9a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->