### PR TITLE
Update Venice image endpoint for image generation

### DIFF
--- a/constants/venice.ts
+++ b/constants/venice.ts
@@ -3,4 +3,4 @@ export const VENICE_API_KEY = 'lnWNeSg0pA_rQUooNpbfpPDBaj2vJnWol5WqKWrIEF';
 
 export const VENICE_MODELS_ENDPOINT = `${VENICE_API_BASE_URL}/models`;
 export const VENICE_CHAT_COMPLETIONS_ENDPOINT = `${VENICE_API_BASE_URL}/chat/completions`;
-export const VENICE_IMAGE_GENERATIONS_ENDPOINT = `${VENICE_API_BASE_URL}/images/generations`;
+export const VENICE_IMAGE_GENERATIONS_ENDPOINT = `${VENICE_API_BASE_URL}/image/generate`;


### PR DESCRIPTION
## Summary
- switch the image generation endpoint to Venice's /image/generate route
- align the image request payload with the new API, including width, height, and format fields
- improve parsing of the image generation response to support multiple payload shapes and mime types

## Testing
- npm run lint (fails: ESLint is not configured for this project)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fb769a2a88331905b4b33b2c2f37d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches to Venice’s /image/generate endpoint, updates payload (width/height/webp, conditional steps/guidance), and adds robust response parsing with mime-type aware data URLs.
> 
> - **Image generation**:
>   - **API endpoint**: Update `VENICE_IMAGE_GENERATIONS_ENDPOINT` to `"/image/generate"` in `constants/venice.ts`.
>   - **Request payload**: In `app/index.tsx` include `width`, `height`, and `format: 'webp'`; conditionally add `steps` and `guidance_scale`; remove `response_format`.
>   - **Response parsing**: Support multiple shapes (`data`, `images`, `data.images`, `outputs`); accept various base64/url keys; infer `mimeType` (including from `format`) and build data URLs; persist `width`/`height` on saved images.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9f77e60afc11f65aedef6d0e9429bf846d40247. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->