### PR TITLE
Improve image generation steps handling and token constraint detection

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -128,7 +128,7 @@ const getModelMaxTokens = (model?: VeniceModel | null): number | undefined => {
     const val = getConstraintNumber((c as any)[key]);
     if (val && val > 0) return val;
   }
-  return model.model_spec?.availableContextTokens;
+  return undefined;
 };
 
 const extractThinkingBlocks = (text: string): { reasoning: string; content: string } => {
@@ -481,12 +481,33 @@ export default function MainScreen() {
     setIsGenerating(true);
 
     try {
+      const stepsConstraint = model.model_spec?.constraints?.steps;
+      const modelDefaultSteps = getConstraintNumber(stepsConstraint);
+      const modelMaxSteps = typeof stepsConstraint === 'object' && stepsConstraint?.max
+        ? stepsConstraint.max : undefined;
+
+      // Use model default steps if available, otherwise user setting
+      let steps = modelDefaultSteps ?? settings.imageSteps ?? 8;
+      // If user has explicitly changed steps from default, respect their setting (capped to model max)
+      if (settings.imageSteps !== DEFAULT_SETTINGS.imageSteps) {
+        steps = settings.imageSteps;
+      }
+      // Cap to model max steps if available
+      if (modelMaxSteps) {
+        steps = Math.min(steps, modelMaxSteps);
+      }
+      // Force 1 step for nano bananapro models
+      const modelIdLower = model.id.toLowerCase();
+      if (modelIdLower.includes('bananapro') || modelIdLower.includes('nano-banana')) {
+        steps = 1;
+      }
+
       const payload = {
         model: model.id,
         prompt,
         width: settings.imageWidth || 1024,
         height: settings.imageHeight || 1024,
-        steps: Math.min(settings.imageSteps || 8, 8),
+        steps,
         cfg_scale: Math.max(1, Math.min(20, settings.imageGuidanceScale || 7.5)),
         format: 'webp',
         hide_watermark: false,

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -54,11 +54,11 @@ const getConstraintNumber = (constraint: any): number | undefined => {
 const getModelMaxTokens = (model?: VeniceModel | null): number | undefined => {
   if (!model) return undefined;
   const c = model.model_spec?.constraints || {};
-  for (const key of ['max_output_tokens', 'maxOutputTokens', 'max_tokens']) {
+  for (const key of ['max_output_tokens', 'maxOutputTokens', 'max_tokens', 'response_tokens']) {
     const val = getConstraintNumber((c as any)[key]);
     if (val && val > 0) return val;
   }
-  return model.model_spec?.availableContextTokens;
+  return undefined;
 };
 
 export default function SettingsScreen() {


### PR DESCRIPTION
## Summary
This PR improves the image generation steps logic to respect model constraints and user preferences, while also enhancing token limit detection to support additional constraint field names.

## Key Changes

- **Image Generation Steps Logic**: Replaced simple capping logic with a more sophisticated approach that:
  - Extracts model default and maximum step constraints from the model spec
  - Respects user-configured step settings when explicitly changed from defaults
  - Caps steps to model maximum when available
  - Forces 1 step for nano-banana and bananapro models (which don't support multiple steps)

- **Token Constraint Detection**: Added `response_tokens` to the list of checked constraint field names for better compatibility with different model specifications

- **Fallback Behavior**: Changed `getModelMaxTokens()` to return `undefined` instead of falling back to `availableContextTokens`, ensuring more predictable behavior when token limits aren't explicitly defined

## Implementation Details

The steps calculation now follows this priority:
1. Check if user has explicitly modified the steps setting from default
2. If not modified, use model default steps if available, otherwise use user setting or 8
3. Cap to model maximum steps if defined
4. Override to 1 step for specific model families that require it

This ensures better UX by respecting user preferences while maintaining compatibility with model constraints.

https://claude.ai/code/session_01GDmUqYtprcH8HVcQJZBdex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how request parameters (`steps` and max tokens) are derived from model specs, which can alter generation behavior across models and potentially affect API compatibility if constraints are unexpected.
> 
> **Overview**
> Improves image generation by computing `steps` from the selected image model’s `constraints.steps` (default/max), honoring user overrides when they differ from `DEFAULT_SETTINGS`, capping to the model max, and forcing `steps=1` for `bananapro`/`nano-banana` models.
> 
> Updates `getModelMaxTokens()` in both `index.tsx` and `settings.tsx` to also detect token limits via `constraints.response_tokens`, and removes the fallback to `model_spec.availableContextTokens` so undefined constraints no longer imply a max token setting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 033f37b3457dd61319202a4535fead3c080e9dc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->