### PR TITLE
UI: preserve scroll, add advanced panels, activity dock & video job progress; copy/download actions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -21,8 +21,14 @@ const NAV = [
 ];
 
 // ── render ──────────────────────────────────────────────────────────────────
+let renderedTool = '';
+let scrollRestoreFrame = 0;
 function render() {
   const tool = state.tool;
+  const previousScroll = $('#main .scroll');
+  const sameTool = renderedTool === tool;
+  const scrollTop = sameTool && previousScroll ? previousScroll.scrollTop : 0;
+  const followBottom = sameTool && previousScroll ? previousScroll.scrollHeight - previousScroll.scrollTop - previousScroll.clientHeight < 56 : false;
   const navMeta = NAV.find(n => n.k === tool) || NAV[0];
   document.documentElement.style.setProperty('--nav-accent', `var(${navMeta.accent})`);
 
@@ -32,6 +38,17 @@ function render() {
   try { section.appendChild(views[tool]()); }
   catch (e) { console.error(e); section.appendChild(el('div', { class: 'pad' }, el('div', { class: 'notice', text: 'Something went wrong rendering this tool.' }))); }
   main.appendChild(section);
+  renderedTool = tool;
+
+  // Progress polling and streamed tokens rebuild the view. Preserve the user's
+  // reading position unless they were already following the newest content.
+  const nextScroll = $('#main .scroll');
+  if (sameTool && nextScroll) {
+    const restore = () => { nextScroll.scrollTop = followBottom ? nextScroll.scrollHeight : scrollTop; };
+    restore();
+    cancelAnimationFrame(scrollRestoreFrame);
+    scrollRestoreFrame = requestAnimationFrame(restore);
+  }
 
   renderNav();
   renderHeader();

--- a/public/styles.css
+++ b/public/styles.css
@@ -375,3 +375,82 @@ input[type=range]::-moz-range-thumb { width: 20px; height: 20px; border: none; b
   .gallery { grid-template-columns: repeat(3, 1fr); }
   .scroll .pad { max-width: 720px; margin: 0 auto; width: 100%; }
 }
+
+/* compact workspace + progressive disclosure -------------------------------- */
+.advanced-panel { padding: 0; overflow: hidden; }
+.advanced-panel > summary { list-style: none; display: flex; align-items: center; gap: 8px; padding: 11px 13px; color: var(--text-2); font-size: 12px; font-weight: 700; letter-spacing: .5px; text-transform: uppercase; cursor: pointer; }
+.advanced-panel > summary::-webkit-details-marker { display: none; }
+.advanced-panel > summary svg:last-child { margin-left: auto; transition: transform .18s ease; }
+.advanced-panel[open] > summary svg:last-child { transform: rotate(180deg); }
+.advanced-body { padding: 2px 13px 13px; border-top: 1px solid var(--border); }
+.advanced-body .field:first-child { margin-top: 12px; }
+.composer-options { display: flex; align-items: center; gap: 8px; padding: 7px 9px 0; color: var(--text-3); font-size: 10px; font-weight: 700; letter-spacing: .7px; text-transform: uppercase; overflow-x: auto; }
+.composer-options .chips { flex-wrap: nowrap; gap: 5px; }
+.composer-options .chip { padding: 4px 8px; font-size: 10px; }
+.msg-actions { display: flex; gap: 7px; margin-top: 9px; }
+.msg-actions .act { padding: 5px 8px; font-size: 11px; opacity: .78; }
+.msg-actions .act:hover { opacity: 1; color: var(--accent); border-color: var(--accent); }
+.job-card { padding: 14px; }
+.job-head { display: flex; align-items: center; gap: 11px; margin-bottom: 13px; }
+.job-card .lp { color: var(--text); font-size: 13px; font-weight: 700; }
+.job-card .ls { color: var(--text-3); font-size: 11px; margin-top: 3px; }
+.job-steps { display: grid; grid-template-columns: repeat(4, 1fr); gap: 5px; margin-bottom: 12px; }
+.job-step { display: flex; flex-direction: column; gap: 5px; color: var(--text-dim); font-size: 9.5px; line-height: 1.25; }
+.job-dot { width: 18px; height: 18px; border-radius: 50%; display: grid; place-items: center; border: 1px solid var(--border-strong); background: rgba(0,0,0,.2); }
+.job-step.done, .job-step.active { color: var(--text-2); }
+.job-step.done .job-dot { color: var(--bg); background: var(--c-enhance); border-color: var(--c-enhance); }
+.job-step.active .job-dot { border-color: var(--accent); background: var(--accent-soft); box-shadow: 0 0 12px -2px var(--accent); }
+.job-step.active .job-dot::after { content: ''; width: 6px; height: 6px; border-radius: 50%; background: var(--accent); }
+.job-card .progress { max-width: none; }
+
+@media (max-width: 719px) {
+  :root { --header-h: 52px; --nav-h: 60px; --radius: 16px; }
+  .app-header { padding: 5px 10px; }
+  .brand-sub { display: none; }
+  .brand-mark { width: 30px; height: 30px; border-radius: 9px; }
+  .header-pill { padding: 6px 9px; max-width: 42vw; font-size: 11px; }
+  .icon-btn { width: 36px; height: 36px; }
+  .tool-head { padding: 10px 12px 2px; }
+  .tool-title { font-size: 18px; gap: 8px; }
+  .tool-title .glyph { width: 26px; height: 26px; }
+  .tool-desc { font-size: 11px; margin-top: 2px; }
+  .segmented { gap: 5px; padding: 7px 12px 2px; }
+  .seg { padding: 7px 10px; font-size: 11px; gap: 5px; }
+  .pad { padding: 10px 12px; }
+  .card { padding: 12px; }
+  .card + .card { margin-top: 9px; }
+  .field { margin-bottom: 10px; }
+  .label { margin-bottom: 5px; font-size: 11.5px; }
+  textarea, input[type=text], input[type=password], input[type=number], select { padding: 9px 10px; border-radius: 10px; font-size: 13px; }
+  textarea { min-height: 62px; }
+  .chips { gap: 5px; }
+  .chip { padding: 6px 9px; font-size: 11px; }
+  .notice { padding: 9px 11px; font-size: 11.5px; }
+  .model-select { padding: 10px 12px !important; }
+  .result-card { margin-bottom: 10px; }
+  .result-meta { padding: 9px 11px; }
+  .act { padding: 6px 8px; font-size: 11px; }
+  .msg { gap: 8px; padding: 10px 12px; }
+  .msg .av { width: 26px; height: 26px; }
+  .msg .content { font-size: 13.5px; line-height: 1.55; }
+  .empty { min-height: 54vh; padding: 26px 20px; }
+  .empty .orb { width: 68px; height: 68px; border-radius: 20px; margin-bottom: 8px; }
+  .nav button { font-size: 9px; }
+  .nav button svg { width: 19px; height: 19px; }
+}
+
+/* persistent generation feedback -------------------------------------------- */
+.activity-dock { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-top: 1px solid var(--border); background: rgba(11,13,24,.92); backdrop-filter: blur(18px); -webkit-backdrop-filter: blur(18px); box-shadow: 0 -10px 24px rgba(0,0,0,.2); }
+.activity-icon { width: 30px; height: 30px; border-radius: 10px; display: grid; place-items: center; flex: none; color: var(--accent); background: var(--accent-soft); border: 1px solid var(--border); animation: activityGlow 1.6s ease-in-out infinite; }
+.activity-body { flex: 1; min-width: 0; }
+.activity-title { color: var(--text); font-size: 11.5px; font-weight: 700; }
+.activity-sub { color: var(--text-3); font-size: 10px; margin: 2px 0 5px; }
+.activity-dock .progress { max-width: none; height: 3px; }
+.activity-pct { color: var(--accent); font-family: var(--font-mono); font-size: 11px; font-weight: 700; }
+.activity-pulse { width: 9px; height: 9px; flex: none; border-radius: 50%; background: var(--accent); box-shadow: 0 0 12px var(--accent); animation: activityPulse 1.25s ease-in-out infinite; }
+.progress.indeterminate > i { width: 38%; animation: progressSlide 1.3s ease-in-out infinite; }
+.job-progress { width: 100%; display: flex; align-items: center; gap: 9px; color: var(--accent); font-family: var(--font-mono); font-size: 10px; font-weight: 700; }
+.job-progress .progress { flex: 1; }
+@keyframes progressSlide { from { transform: translateX(-115%); } to { transform: translateX(300%); } }
+@keyframes activityPulse { 0%, 100% { opacity: .45; transform: scale(.8); } 50% { opacity: 1; transform: scale(1.08); } }
+@keyframes activityGlow { 0%, 100% { box-shadow: 0 0 0 transparent; } 50% { box-shadow: 0 0 16px -5px var(--accent); } }

--- a/public/tools.js
+++ b/public/tools.js
@@ -16,17 +16,18 @@ import {
 // per-view form state (kept across re-renders within a session)
 const F = {
   chat: { atts: [], webSearch: 'auto', effort: '' },
-  imgGen: { prompt: '', negative: '', ratio: '16:9', resolution: '', quality: '', steps: null, cfg: 5, style: '', variants: 1, seed: '', format: 'webp', hideWm: false },
+  imgGen: { prompt: '', negative: '', ratio: '16:9', resolution: '', quality: '', steps: null, cfg: 5, style: '', variants: 1, seed: '', format: 'webp', hideWm: false, advanced: false },
   edit: { prompt: '', images: [], ratio: 'auto', resolution: '', quality: '', format: '' },
   enhance: { image: null, scale: 2, enhance: true, creativity: 0.5, replication: 0.35, prompt: '' },
   bg: { image: null },
   video: { prompt: '', negative: '', duration: '', ratio: '', resolution: '', audio: true, image: null, endImage: null, quote: null },
   music: { prompt: '', lyrics: '', optimizer: false, instrumental: false, voice: '', lang: '', duration: null, speed: null, quote: null },
-  speech: { text: '', voice: '', format: 'mp3', speed: 1, lang: '', style: '', temperature: 0.7, topP: 1 },
+  speech: { text: '', voice: '', format: 'mp3', speed: 1, lang: '', style: '', temperature: 0.7, topP: 1, advanced: false },
   transcribe: { audio: null, filename: '', text: '', language: '' },
 };
 const recent = { image: [], video: [], audio: [] }; // inline results per view
 const busy = {};                                      // view -> bool
+const jobState = {};                                  // async job lifecycle for progress UI
 let chat = { messages: [], streaming: false, abort: null };
 
 // ── small control builders ──────────────────────────────────────────────────
@@ -81,10 +82,76 @@ function select(options, value, onChange, labels) {
   s.addEventListener('change', e => onChange(e.target.value));
   return s;
 }
+function advancedPanel(title, children, open = false, onToggle) {
+  const panel = el('details', { class: 'advanced-panel card', open }, [
+    el('summary', { html: `${icon('sliders', 14)}<span>${title}</span>${icon('chevronDown', 15)}` }),
+    el('div', { class: 'advanced-body' }, children),
+  ]);
+  if (onToggle) panel.addEventListener('toggle', () => onToggle(panel.open));
+  return panel;
+}
+function copyText(text) {
+  if (!text) return;
+  const write = navigator.clipboard?.writeText(text);
+  if (!write) { toast('Clipboard is not available', 'err'); return; }
+  write.then(() => toast('Copied', 'ok')).catch(() => toast('Could not copy', 'err'));
+}
+function downloadText(text, filename = 'vgpt-response.txt') {
+  if (!text) return;
+  const url = URL.createObjectURL(new Blob([text], { type: 'text/plain;charset=utf-8' }));
+  downloadDataUrl(url, filename);
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+function appendActivityDock(parent, view) {
+  const dock = activityDock(view);
+  if (dock) parent.appendChild(dock);
+}
+function activityDock(view) {
+  const isChat = view === 'chat';
+  const active = isChat ? chat.streaming : busy[view];
+  if (!active) return null;
+  const progress = typeof active === 'number' ? Math.max(0.02, Math.min(0.99, active)) : null;
+  const pct = progress == null ? null : Math.round(progress * 100);
+  const labels = { chat: 'vGPT is writing', image: 'Creating image', video: 'Generating video', audio: 'Generating audio' };
+  const sub = view === 'video' ? (jobState.video?.status || jobState.video?.stage || 'preparing') : pct != null ? `${pct}% complete` : 'Generation in progress';
+  return el('div', { class: 'activity-dock', role: 'status', 'aria-live': 'polite' }, [
+    el('div', { class: 'activity-icon', html: icon(view === 'chat' ? 'sparkles' : view === 'image' ? 'image' : view === 'video' ? 'video' : 'music', 15) }),
+    el('div', { class: 'activity-body' }, [
+      el('div', { class: 'activity-title', text: labels[view] }),
+      el('div', { class: 'activity-sub', text: String(sub).replace(/_/g, ' ').toLowerCase() }),
+      el('div', { class: `progress ${pct == null ? 'indeterminate' : ''}` }, el('i', { style: pct == null ? {} : { width: pct + '%' } })),
+    ]),
+    pct != null ? el('div', { class: 'activity-pct', text: pct + '%' }) : el('div', { class: 'activity-pulse' }),
+  ]);
+}
 function generateBar(label, accentIcon, onClick, disabled, priceNote) {
   return el('div', { class: 'generate-bar' }, [
     priceNote ? el('div', { class: 'hint', style: { textAlign: 'center', marginBottom: '8px' }, html: priceNote }) : null,
     el('button', { class: 'btn primary full', disabled, html: `${icon(accentIcon, 18)} ${label}`, onclick: onClick }),
+  ]);
+}
+function videoProgressCard(progress) {
+  const js = jobState.video || { stage: 'preparing' };
+  const stages = [
+    ['preparing', 'Preparing request'],
+    ['queued', 'Queued with Venice'],
+    ['rendering', 'Rendering frames'],
+    ['finalizing', 'Finalizing media'],
+  ];
+  const active = Math.max(0, stages.findIndex(([key]) => key === js.stage));
+  return el('div', { class: 'card job-card' }, [
+    el('div', { class: 'job-head' }, [el('div', { class: 'spinner sm' }), el('div', {}, [
+      el('div', { class: 'lp', text: js.stage === 'queued' ? 'Your video is queued' : js.stage === 'finalizing' ? 'Finalizing your video…' : 'Rendering your video…' }),
+      el('div', { class: 'ls', text: js.status ? String(js.status).replace(/_/g, ' ').toLowerCase() : 'Keep this screen open while Venice creates your clip.' }),
+    ])]),
+    el('div', { class: 'job-steps' }, stages.map(([key, label], i) => el('div', { class: `job-step ${i < active ? 'done' : i === active ? 'active' : ''}` }, [
+      el('span', { class: 'job-dot', html: i < active ? icon('check', 11) : '' }),
+      el('span', { text: label }),
+    ]))),
+    el('div', { class: 'job-progress' }, [
+      el('div', { class: 'progress' }, el('i', { style: { width: Math.round((typeof progress === 'number' ? progress : 0.06) * 100) + '%' } })),
+      el('span', { text: Math.round((typeof progress === 'number' ? progress : 0.06) * 100) + '%' }),
+    ]),
   ]);
 }
 function loadingCard(primary, sub, progress) {
@@ -92,7 +159,7 @@ function loadingCard(primary, sub, progress) {
     el('div', { class: 'spinner' }),
     el('div', { class: 'lp', text: primary }),
     sub ? el('div', { class: 'ls', text: sub }) : null,
-    progress != null ? el('div', { class: 'progress' }, el('i', { style: { width: Math.round(progress * 100) + '%' } })) : null,
+    progress != null ? el('div', { class: 'job-progress' }, [el('div', { class: 'progress' }, el('i', { style: { width: Math.round(progress * 100) + '%' } })), el('span', { text: Math.round(progress * 100) + '%' })]) : null,
   ]);
 }
 const ACCENT2 = { '--c-chat': '#ff8a4c', '--c-image': '#ffce4c', '--c-edit': '#ff8a4c', '--c-enhance': '#21d4fd', '--c-video': '#21d4fd', '--c-music': '#4b8bff', '--c-voice': '#21d4fd', '--c-library': '#ff8ad0' };
@@ -152,7 +219,7 @@ function resultCard(asset) {
 
   const acts = el('div', { class: 'result-actions' });
   const dlName = `vgpt-${asset.id}.${asset.ext || (asset.kind === 'image' ? 'png' : asset.kind === 'video' ? 'mp4' : 'mp3')}`;
-  acts.appendChild(el('button', { class: 'act', html: `${icon('download', 14)} Save`, onclick: () => downloadDataUrl(asset.dataUrl, dlName) }));
+  acts.appendChild(el('button', { class: 'act', html: `${icon('download', 14)} Download`, onclick: () => downloadDataUrl(asset.dataUrl, dlName) }));
   if (asset.kind === 'image') {
     acts.appendChild(el('button', { class: 'act accent', html: `${icon('wand', 14)} Edit`, onclick: () => nav.goTo('image', { mode: 'edit', handoff: { image: asset.dataUrl } }) }));
     acts.appendChild(el('button', { class: 'act', html: `${icon('upscale', 14)} Enhance`, onclick: () => nav.goTo('image', { mode: 'enhance', handoff: { image: asset.dataUrl } }) }));
@@ -199,7 +266,7 @@ async function runJob(view, fn) {
   busy[view] = true; nav.refresh();
   try { await fn(); }
   catch (e) { toast(e.message || 'Something went wrong', 'err'); }
-  finally { busy[view] = false; nav.refresh(); }
+  finally { busy[view] = false; if (view === 'video') delete jobState.video; nav.refresh(); }
 }
 
 // ════════════════════════════ CHAT ════════════════════════════
@@ -231,7 +298,6 @@ function viewChat() {
     const list = el('div', { class: 'chat-list' });
     chat.messages.forEach(msg => list.appendChild(renderMsg(msg)));
     scroll.appendChild(list);
-    setTimeout(() => scroll.scrollTo({ top: scroll.scrollHeight }), 0);
   }
 
   // composer
@@ -249,6 +315,10 @@ function viewChat() {
   const sendBtn = el('button', { class: 'cbtn send', html: chat.streaming ? icon('x', 18) : icon('send', 18), onclick: () => chat.streaming ? stopChat() : send() });
 
   const composer = el('div', { class: 'composer' }, [
+    caps.reasoningEffort ? el('div', { class: 'composer-options' }, [
+      el('span', { text: 'Reasoning' }),
+      chips(['', ...(caps.effortOptions || ['low', 'medium', 'high'])], F.chat.effort, v => { F.chat.effort = v; nav.refresh(); }, v => v || 'Auto'),
+    ]) : null,
     F.chat.atts.length ? atts : null,
     el('div', { class: 'composer-inner' }, [attachBtn, ta, webBtn, sendBtn].filter(Boolean)),
   ]);
@@ -267,6 +337,7 @@ function viewChat() {
   }
 
   frag.appendChild(scroll);
+  appendActivityDock(frag, 'chat');
   frag.appendChild(composer);
   return frag;
 }
@@ -290,6 +361,12 @@ function renderMsg(msg) {
     body.appendChild(el('details', { class: 'reasoning' }, [
       el('summary', { html: `${icon('sparkles', 14)} Reasoning` }),
       el('div', { class: 'r-body', text: msg.reasoning }),
+    ]));
+  }
+  if (!isUser && !msg.streaming && msg.content) {
+    body.appendChild(el('div', { class: 'msg-actions' }, [
+      el('button', { class: 'act', html: `${icon('copy', 14)} Copy`, onclick: () => copyText(msg.content) }),
+      el('button', { class: 'act', html: `${icon('download', 14)} Download`, onclick: () => downloadText(msg.content) }),
     ]));
   }
   if (!isUser && msg.metrics) {
@@ -379,6 +456,7 @@ function viewImage() {
   const pad = el('div', { class: 'pad pad-b' });
   scroll.appendChild(pad);
   frag.appendChild(scroll);
+  appendActivityDock(frag, 'image');
 
   if (mode === 'generate') buildGenerate(pad);
   else if (mode === 'edit') buildEdit(pad);
@@ -391,10 +469,11 @@ function resultsBlock(view) {
   const out = el('div', {});
   if (busy[view]) {
     const prog = busy[view] === true ? null : busy[view];
-    out.appendChild(loadingCard(
+    if (view === 'video') out.appendChild(videoProgressCard(prog));
+    else out.appendChild(loadingCard(
       view === 'video' ? 'Rendering your video…' : view === 'audio' ? 'Composing audio…' : 'Generating…',
       view === 'video' || view === 'audio' ? 'This can take 1–3 minutes. Keep this screen open.' : 'Usually a few seconds.',
-      typeof prog === 'number' ? prog : (view === 'video' || view === 'audio' ? 0.06 : null),
+      typeof prog === 'number' ? prog : (view === 'audio' ? 0.06 : null),
     ));
   }
   recent[view].forEach(a => out.appendChild(resultCard(a)));
@@ -437,15 +516,15 @@ function buildGenerate(pad) {
   pad.appendChild(form);
 
   // advanced (style, variants, seed, format)
-  const adv = el('div', { class: 'card' });
-  adv.appendChild(el('div', { class: 'panel-title', html: `${icon('sliders', 13)} Options` }));
+  const advBody = [];
   if (state.styles.length) {
-    adv.appendChild(field('Style preset', select(['', ...state.styles], f.style, v => f.style = v, o2 => o2 || 'None')));
+    advBody.push(field('Style preset', select(['', ...state.styles], f.style, v => f.style = v, o2 => o2 || 'None')));
   }
-  adv.appendChild(field('Variants', chips([1, 2, 3, 4], f.variants, v => { f.variants = v; nav.refresh(); }), 'Generate multiple options at once'));
-  adv.appendChild(field('Output format', chips(['webp', 'png', 'jpeg'], f.format, v => { f.format = v; nav.refresh(); })));
-  adv.appendChild(field('Seed', (() => { const i = el('input', { type: 'number', placeholder: 'Random', value: f.seed }); i.addEventListener('input', e => f.seed = e.target.value); return i; })(), 'Reuse a seed for reproducible results'));
-  pad.appendChild(adv);
+  advBody.push(field('Variants', chips([1, 2, 3, 4], f.variants, v => { f.variants = v; nav.refresh(); }), 'Generate multiple options at once'));
+  advBody.push(field('Output format', chips(['webp', 'png', 'jpeg'], f.format, v => { f.format = v; nav.refresh(); })));
+  advBody.push(field('Seed', (() => { const i = el('input', { type: 'number', placeholder: 'Random', value: f.seed }); i.addEventListener('input', e => f.seed = e.target.value); return i; })(), 'Reuse a seed for reproducible results'));
+  advBody.push(switchRow('Hide watermark', f.hideWm, v => { f.hideWm = v; nav.refresh(); }, 'Only applies when supported by the selected image model'));
+  pad.appendChild(advancedPanel('Advanced options', advBody, f.advanced, open => f.advanced = open));
 
   pad.appendChild(resultsBlock('image'));
 
@@ -588,6 +667,7 @@ function viewVideo() {
   const scroll = el('div', { class: 'scroll' });
   const pad = el('div', { class: 'pad pad-b' });
   scroll.appendChild(pad); frag.appendChild(scroll);
+  appendActivityDock(frag, 'video');
 
   const id = selectedFor('video');
   const m = findModel(id);
@@ -639,9 +719,16 @@ function viewVideo() {
     if (o.audioConfigurable) body.audio = !!f.audio;
     if (f.negative.trim()) body.negative_prompt = f.negative.trim();
     if (o.allowsImage && f.image) body.image_url = f.image;
+    jobState.video = { stage: 'preparing' }; nav.refresh();
     const q = await api.videoQueue(body);
     if (!q.queue_id) throw new Error('Could not queue video');
-    const url = await pollJob('video', { model: id, queueId: q.queue_id, downloadUrl: q.download_url }, (p) => { busy.video = (p == null || p <= 0.02) ? true : p; nav.refresh(); });
+    jobState.video = { stage: 'queued', status: 'waiting in queue', queueId: q.queue_id }; nav.refresh();
+    const url = await pollJob('video', { model: id, queueId: q.queue_id, downloadUrl: q.download_url }, (p, status) => {
+      const statusText = status || 'rendering';
+      const finalizing = /complete|final/i.test(statusText) || (typeof p === 'number' && p > 0.92);
+      jobState.video = { stage: finalizing ? 'finalizing' : 'rendering', status: statusText, queueId: q.queue_id };
+      busy.video = (p == null || p <= 0.02) ? true : p; nav.refresh();
+    });
     const a = addAsset({ kind: 'video', dataUrl: url, prompt: f.prompt.trim(), model: id, modelName: modelName(id), ext: 'mp4' });
     recent.video.unshift(a);
     toast('Video ready', 'ok');
@@ -667,6 +754,7 @@ function viewAudio() {
   const scroll = el('div', { class: 'scroll' });
   const pad = el('div', { class: 'pad pad-b' });
   scroll.appendChild(pad); frag.appendChild(scroll);
+  appendActivityDock(frag, 'audio');
 
   if (mode === 'music') buildMusic(pad);
   else if (mode === 'speech') buildSpeech(pad);
@@ -739,9 +827,15 @@ function buildSpeech(pad) {
   form.appendChild(field('Format', chips(['mp3', 'opus', 'aac', 'flac', 'wav'], f.format, v => { f.format = v; nav.refresh(); })));
   form.appendChild(field('Speed', slider(0.25, 4, 0.05, f.speed, v => { f.speed = v; updateVal(form, 'sp', v.toFixed(2) + '×'); }), null, f.speed.toFixed(2) + '×')); markVal(form, 'sp');
   form.appendChild(field('Language (optional)', (() => { const i = el('input', { type: 'text', placeholder: 'e.g. en, English, ja', value: f.lang }); i.addEventListener('input', e => f.lang = e.target.value); return i; })()));
-  if (o.supportsPrompt) form.appendChild(field('Style direction', (() => { const i = el('input', { type: 'text', placeholder: 'e.g. Very happy. Excited.', value: f.style }); i.addEventListener('input', e => f.style = e.target.value); return i; })()));
-  if (o.supportsTemperature) { form.appendChild(field('Temperature', slider(0, 2, 0.05, f.temperature, v => { f.temperature = v; updateVal(form, 'tm', v.toFixed(2)); }), null, f.temperature.toFixed(2))); markVal(form, 'tm'); }
   pad.appendChild(form);
+  const speechAdvanced = [];
+  if (o.supportsPrompt) speechAdvanced.push(field('Style direction', (() => { const i = el('input', { type: 'text', placeholder: 'e.g. Very happy. Excited.', value: f.style }); i.addEventListener('input', e => f.style = e.target.value); return i; })()));
+  if (o.supportsTemperature) speechAdvanced.push(field('Temperature', slider(0, 2, 0.05, f.temperature, v => { f.temperature = v; updateVal(speechAdv, 'tm', v.toFixed(2)); }), null, f.temperature.toFixed(2)));
+  if (o.supportsTopP) speechAdvanced.push(field('Top P', slider(0, 1, 0.05, f.topP, v => { f.topP = v; updateVal(speechAdv, 'tp', v.toFixed(2)); }), null, f.topP.toFixed(2)));
+  const speechAdv = advancedPanel('Voice tuning', speechAdvanced, f.advanced, open => f.advanced = open);
+  if (o.supportsTemperature) markVal(speechAdv, 'tm');
+  if (o.supportsTopP) markVal(speechAdv, 'tp');
+  if (speechAdvanced.length) pad.appendChild(speechAdv);
 
   pad.appendChild(resultsBlock('audio'));
   pad.appendChild(generateBar(busy.audio ? 'Synthesising…' : 'Generate speech', 'volume', () => runJob('audio', async () => {
@@ -782,7 +876,8 @@ function buildTranscribe(pad) {
     el('div', { class: 'panel-title', html: `${icon('type', 13)} Transcript` }),
     el('div', { style: { fontSize: '14px', lineHeight: '1.6', whiteSpace: 'pre-wrap', color: 'var(--text)' }, text: f.text }),
     el('div', { class: 'result-actions' }, [
-      el('button', { class: 'act', html: `${icon('copy', 14)} Copy`, onclick: () => { navigator.clipboard?.writeText(f.text); toast('Copied', 'ok'); } }),
+      el('button', { class: 'act', html: `${icon('copy', 14)} Copy`, onclick: () => copyText(f.text) }),
+      el('button', { class: 'act', html: `${icon('download', 14)} Download`, onclick: () => downloadText(f.text, 'vgpt-transcript.txt') }),
       el('button', { class: 'act', html: `${icon('chat', 14)} Send to chat`, onclick: () => { newChat(); chat.messages.push({ role: 'user', content: f.text, display: f.text }); nav.goTo('chat'); runChat(); } }),
     ]),
   ]));
@@ -828,7 +923,7 @@ function openAsset(a) {
 }
 
 // helpers to update a slider's value label without full re-render
-function markVal(form, key) { const f = form.querySelector('.field:last-child .val'); if (f) f.dataset.k = key; }
+function markVal(form, key) { const f = Array.from(form.querySelectorAll('.val')).find(n => !n.dataset.k); if (f) f.dataset.k = key; }
 function updateVal(form, key, text) { const node = Array.from(form.querySelectorAll('.val')).find(n => n.dataset.k === key); if (node) node.textContent = text; }
 
 // header pill context for the current tool/mode


### PR DESCRIPTION
### Motivation
- Preserve user reading position across re-renders when streaming tokens or polling progress to avoid jarring scroll jumps.
- Provide persistent generation feedback and richer job lifecycle visibility (especially for video) so users can monitor progress without losing context.
- Expose advanced model options in compact, progressive panels and add convenient copy/download actions for textual responses and transcripts.

### Description
- Preserve and restore scroll position when re-rendering the same tool by tracking `renderedTool` and using `requestAnimationFrame` in `public/app.js`.
- Add CSS for compact workspace, advanced panels, activity dock, and job progress visuals in `public/styles.css` to support the new UI elements and responsive behaviors.
- Introduce new helpers and UI in `public/tools.js`: `advancedPanel`, `copyText`, `downloadText`, `activityDock`, and `videoProgressCard`, plus a `jobState` object to track async job stages; wire activity docks into chat/image/video/audio views and show video job stages updated by the `pollJob` callback.
- Update behavior and visuals: improve `loadingCard` to show percent/job progress, change result action label `Save`→`Download`, add copy/download buttons for assistant messages and transcripts, add advanced toggles to image and speech forms, and clear `jobState.video` after video jobs complete.
- Small fixes: adjust `markVal` to correctly assign value labels and ensure `runJob` clears video job state on finalize.

### Testing
- Ran `npm run lint` which completed successfully.
- Ran `npm run build` which completed successfully and produced the expected frontend bundle.
- Performed a local development smoke test by launching the dev server and exercising chat/image/video/audio flows to validate UI rendering and progress indicators (no automated unit tests were changed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a7171bc40833190a66a7e4951078d)